### PR TITLE
Fix bug with zero trigger vals

### DIFF
--- a/app/measurement/models.py
+++ b/app/measurement/models.py
@@ -238,12 +238,11 @@ class Trigger(MeasurementBase):
         '''
         val = channel_value[self.monitor.stat]
         # check three cases: only minval, only maxval, both min and max
-        if not self.minval and not self.maxval:
-            print('minval or maxval should be defined!')
+        if self.minval is None and self.maxval is None:
             return False
-        elif self.minval and not self.maxval:
+        elif self.minval is not None and self.maxval is None:
             return val < self.minval
-        elif not self.minval and self.maxval:
+        elif self.minval is None and self.maxval is not None:
             return val > self.maxval
         else:
             inside_band = (val > self.minval and val < self.maxval)

--- a/app/measurement/tests/test_alarms_api.py
+++ b/app/measurement/tests/test_alarms_api.py
@@ -592,3 +592,18 @@ class PrivateAlarmAPITests(TestCase):
         # Verify results are reverse sorted by timestamps
         timestamps = [alert['timestamp'] for alert in res.data]
         self.assertTrue(sorted(timestamps, reverse=True) == timestamps)
+
+    def test_trigger_with_zero_vals(self):
+        trigger_test = Trigger.objects.create(
+            monitor=self.monitor,
+            minval=0,
+            maxval=None,
+            level=Trigger.Level.ONE,
+            user=self.user
+        )
+
+        channel_value = {}
+        channel_value[trigger_test.monitor.stat] = -1
+        self.assertTrue(trigger_test.is_breaching(channel_value))
+        channel_value[trigger_test.monitor.stat] = 1
+        self.assertFalse(trigger_test.is_breaching(channel_value))


### PR DESCRIPTION
A minval or maxval of zero was treated as if it were None when processing alarms.