### PR TITLE
Update load_from_fdsn.py, include all ANSS RSNs

### DIFF
--- a/app/nslc/management/commands/load_from_fdsn.py
+++ b/app/nslc/management/commands/load_from_fdsn.py
@@ -130,7 +130,6 @@ class Command(BaseCommand):
 
     '''Django command to check network and channel tables with FDSN service'''
     def handle(self, *args, **options):
-        # &net=AK,AV,AZ,BC,BK,CC,CE,CI,CN,ET,HV,IU,IW,MB,NC,NN,NP,NV,OK,OO,PB,PR,SN,TX,UM,UO,US,UU,UW
         ALLOWED_NETWORKS = [
             "AK", "AV", "AZ", "BC", "BK", "CC", "CE", "CI", "CN", "ET", "HV",
             "IU", "IW", "MB", "NC", "NN", "NP", "NV", "OK", "OO", "PB", "PR",

--- a/app/nslc/management/commands/load_from_fdsn.py
+++ b/app/nslc/management/commands/load_from_fdsn.py
@@ -130,9 +130,11 @@ class Command(BaseCommand):
 
     '''Django command to check network and channel tables with FDSN service'''
     def handle(self, *args, **options):
+        # &net=AK,AV,AZ,BC,BK,CC,CE,CI,CN,ET,HV,IU,IW,MB,NC,NN,NP,NV,OK,OO,PB,PR,SN,TX,UM,UO,US,UU,UW
         ALLOWED_NETWORKS = [
-            "AZ", "BC", "BK", "CC", "CE", "CI", "CN", "IU", "IW", "MB", "NC",
-            "NN", "NP", "NV", "OO", "PB", "SN", "UO", "US", "UW"
+            "AK", "AV", "AZ", "BC", "BK", "CC", "CE", "CI", "CN", "ET", "HV",
+            "IU", "IW", "MB", "NC", "NN", "NP", "NV", "OK", "OO", "PB", "PR",
+            "SN", "TX", "UM", "UO", "US", "UU", "UW"
         ]
         options["net"] = ','.join(ALLOWED_NETWORKS)
         LOADER_EMAIL = os.environ.get('LOADER_EMAIL')

--- a/app/nslc/management/commands/load_from_fdsn.py
+++ b/app/nslc/management/commands/load_from_fdsn.py
@@ -4,14 +4,14 @@ Command run without any options will give default URL
         query?datacenter=IRISDMC,NCEDC,SCEDC
         &targetservice=station
         &level=channel
-        &net=AZ,BC,BK,CC,CE,CI,CN,IU,IW,MB,NC,NN,NP,NV,OO,PB,SN,UO,US,UW
+        &net=AK,AV,AZ,BC,BK,CC,CE,CI,CN,ET,HV,IU,IW,MB,NC,NN,NP,NV,OK,OO,PB,PR,SN,TX,UM,UO,US,UU,UW
         &sta=*
         &cha=EN?,HN?,?H?
         &loc=*
-        &minlat=30.5
-        &maxlat=51
-        &minlon=-131
-        &maxlon=-113
+        &minlat=12.
+        &maxlat=72.
+        &minlon=-179.99
+        &maxlon=-62.
         &starttime=2019-01-01
         &format=text
 
@@ -24,10 +24,10 @@ $:docker-compose run --rm app sh -c "LOADER_EMAIL=email@pnsn.org \
                     --sta='BEER,...'
                     --cha='HN?,ENN,...'
                     --loc=*
-                    --minlat=31.5
-                    --maxlat=50
-                    --minlon=-128.1
-                    --maxlon=-113.9
+                    --minlat=12.
+                    --maxlat=72.
+                    --minlon=-179.99
+                    --maxlon=-62.
                     --starttime='YYYY-mm-dd'"
 
  text response from fdsn has following schema:
@@ -78,23 +78,23 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--minlat',
-            default=30.5,
-            help="Lower latitude for search box, 30.5 default"
+            default=12,
+            help="Lower latitude for search box, 12 default"
         )
         parser.add_argument(
             '--maxlat',
-            default=51,
-            help="Upper latitude for search box, 51 default"
+            default=72,
+            help="Upper latitude for search box, 72 default"
         )
         parser.add_argument(
             '--minlon',
-            default=-131,
-            help="Left latitude for search box, -131 default"
+            default=-179.99,
+            help="Left latitude for search box, -179.99 default"
         )
         parser.add_argument(
             '--maxlon',
             default=-113,
-            help="Right latitude for search box, -113 default"
+            help="Right latitude for search box, -62 default"
         )
         parser.add_argument(
             '--starttime',

--- a/app/nslc/management/commands/load_from_fdsn.py
+++ b/app/nslc/management/commands/load_from_fdsn.py
@@ -32,7 +32,7 @@ $:docker-compose run --rm app sh -c "LOADER_EMAIL=email@pnsn.org \
 
  text response from fdsn has following schema:
  Network | Station | Location | Channel | Latitude | Longitude |
- Elevation | Depth | Azimuth | Dip | SensfrDescription | Scale |
+ Elevation | Depth | Azimuth | Dip | SensorDescription | Scale |
  ScaleFreq | ScaleUnits | SampleRate | StartTime | EndTime
 """
 import csv

--- a/app/nslc/management/commands/load_from_fdsn.py
+++ b/app/nslc/management/commands/load_from_fdsn.py
@@ -32,7 +32,7 @@ $:docker-compose run --rm app sh -c "LOADER_EMAIL=email@pnsn.org \
 
  text response from fdsn has following schema:
  Network | Station | Location | Channel | Latitude | Longitude |
- Elevation | Depth | Azimuth | Dip | SensorDescription | Scale |
+ Elevation | Depth | Azimuth | Dip | SensfrDescription | Scale |
  ScaleFreq | ScaleUnits | SampleRate | StartTime | EndTime
 """
 import csv
@@ -93,7 +93,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--maxlon',
-            default=-113,
+            default=-62,
             help="Right latitude for search box, -62 default"
         )
         parser.add_argument(

--- a/app/nslc/management/commands/load_from_fdsn.py
+++ b/app/nslc/management/commands/load_from_fdsn.py
@@ -10,7 +10,7 @@ Command run without any options will give default URL
         &loc=*
         &minlat=12.
         &maxlat=72.
-        &minlon=-179.99
+        &minlon=-183.
         &maxlon=-62.
         &starttime=2019-01-01
         &format=text
@@ -26,7 +26,7 @@ $:docker-compose run --rm app sh -c "LOADER_EMAIL=email@pnsn.org \
                     --loc=*
                     --minlat=12.
                     --maxlat=72.
-                    --minlon=-179.99
+                    --minlon=-183.
                     --maxlon=-62.
                     --starttime='YYYY-mm-dd'"
 
@@ -88,8 +88,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--minlon',
-            default=-179.99,
-            help="Left latitude for search box, -179.99 default"
+            default=-183.,
+            help="Left latitude for search box, -183. default"
         )
         parser.add_argument(
             '--maxlon',


### PR DESCRIPTION
Can we please expand the NSLC list and boundaries to include all ANSS RSNs?  Note: this will add lots of NSLCs, but I'm not sure how many.