### PR TITLE
Change default start time of monitor.evaluate_alarm

### DIFF
--- a/app/measurement/models.py
+++ b/app/measurement/models.py
@@ -8,6 +8,7 @@ from dashboard.models import Widget
 from nslc.models import Channel, Group
 
 from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 import pytz
 
 from bulk_update_or_create import BulkUpdateOrCreateQuerySet
@@ -207,10 +208,12 @@ class Monitor(MeasurementBase):
 
         return q_list
 
-    def evaluate_alarm(self, endtime=datetime.now(tz=pytz.UTC)):
+    def evaluate_alarm(self, endtime=(datetime.now(tz=pytz.UTC) -
+                       relativedelta(minute=0, second=0, microsecond=0))):
         '''
         Higher-level function that determines alarm state and calls other
-        functions to create alerts if necessary
+        functions to create alerts if necessary. Default is to start on the
+        hour regardless of when it is called (truncate down).
         '''
         # Get aggregate values for each channel. Returns a list(QuerySet)
         channel_values = self.agg_measurements(endtime)

--- a/app/measurement/models.py
+++ b/app/measurement/models.py
@@ -208,8 +208,8 @@ class Monitor(MeasurementBase):
 
         return q_list
 
-    def evaluate_alarm(self, endtime=(datetime.now(tz=pytz.UTC) -
-                       relativedelta(minute=0, second=0, microsecond=0))):
+    def evaluate_alarm(self, endtime=datetime.now(tz=pytz.UTC) - relativedelta(
+                       minute=0, second=0, microsecond=0)):
         '''
         Higher-level function that determines alarm state and calls other
         functions to create alerts if necessary. Default is to start on the


### PR DESCRIPTION
Previous default reference time for evaluating monitors was datetime.now(). Changed so that it is exactly on the hour, truncated down from datetime.now().