### PR TITLE
Enable weekly archives plus cron updates

### DIFF
--- a/app/measurement/management/commands/s3_query_export.py
+++ b/app/measurement/management/commands/s3_query_export.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--start_date',
             type=lambda s: datetime.strptime(s, "%Y-%m-%d").date(),
-            default=(datetime.now(tz=pytz.utc) - timedelta(days=3)).date(),
+            default=(datetime.now(tz=pytz.utc) - timedelta(days=7)).date(),
             help="When to start backup (inclusive, format: YYYY-MM-DD)"
         )
         parser.add_argument(

--- a/app/squac/cronjobs.py
+++ b/app/squac/cronjobs.py
@@ -12,6 +12,8 @@ CRONJOBS = [  # noqa
     ('0 5 * * *', 'django.core.management.call_command', ['s3_query_export']),
     ('0 6 1,10 * *', 'django.core.management.call_command',
         ['archive_measurements', 'month']),
+    ('0 7 * * 1', 'django.core.management.call_command',
+        ['backfill_archives', 'week', '--overwrite'], {'period_size': 1}),
     ('30 5 * * *', 'django.core.management.call_command',
-        ['backfill_archives', 'day', '--overwrite'])
+        ['backfill_archives', 'day', '--overwrite'], {'period_size': 6})
 ]


### PR DESCRIPTION
- Addresses issue #397, enabling weekly archives
- Updated backfill_archives script to allow `period_size` intervals before the `end_time`
- Added weekly archiving to cronjobs (will do last week and the previous week on each Monday)
- Changed daily archives cronjob to backfill the previous 7 days, in case of late data