### PR TITLE
fix params for measurements

### DIFF
--- a/app/measurement/params.py
+++ b/app/measurement/params.py
@@ -5,31 +5,31 @@ from drf_yasg import openapi
 '''
 
 metric_param = openapi.Parameter(
-    'metric', openapi.IN_QUERY,
+    'metric',
+    openapi.IN_QUERY,
     description="Comma separated list of metric ids",
     type=openapi.TYPE_ARRAY,
-    items=openapi.Items(type=openapi.TYPE_INTEGER),
-    collection_format='multi')
+    items=openapi.Items(type=openapi.TYPE_INTEGER))
 
 channel_param = openapi.Parameter(
-    'channel', openapi.IN_QUERY,
+    'channel',
+    openapi.IN_QUERY,
     description="Comma separated list of channel ids",
     type=openapi.TYPE_ARRAY,
-    items=openapi.Items(type=openapi.TYPE_INTEGER),
-    collection_format='multi')
+    items=openapi.Items(type=openapi.TYPE_INTEGER))
 
 nslc_param = openapi.Parameter(
-    'nslc', openapi.IN_QUERY,
+    'nslc',
+    openapi.IN_QUERY,
     description="Comma separated list of channel nslcs",
     type=openapi.TYPE_ARRAY,
-    items=openapi.Items(type=openapi.TYPE_STRING),
-    collection_format='multi')
+    items=openapi.Items(type=openapi.TYPE_STRING))
 
 group_param = openapi.Parameter(
-    'group', openapi.IN_QUERY,
+    'group',
+    openapi.IN_QUERY,
     description="Comma separated list of channel group ids",
     type=openapi.TYPE_ARRAY,
-    items=openapi.Items(type=openapi.TYPE_INTEGER),
-    collection_format='multi')
+    items=openapi.Items(type=openapi.TYPE_INTEGER))
 
 measurement_params = [metric_param, channel_param, nslc_param, group_param, ]


### PR DESCRIPTION
Removed the openapi collectionFormat: "multi" that caused the query params to be exploded