### PR TITLE
Handle default datetime correctly, update unit tests

### DIFF
--- a/app/measurement/tests/test_alarms_api.py
+++ b/app/measurement/tests/test_alarms_api.py
@@ -4,7 +4,6 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
-# from django.db.models import Avg, Count, Max, Min, Sum
 
 from measurement.models import (Monitor, Trigger, Alert, Measurement,
                                 Metric)
@@ -199,8 +198,11 @@ class PrivateAlarmAPITests(TestCase):
         trigger.alert_on_out_of_alarm = True
         trigger.save()
 
+        # saving the trigger created a new alert with in_alarm=False
+        # so make another with in_alarm=True
+        old_alert = trigger.create_alert(True)
         alert = trigger.evaluate_alert(False)
-        self.assertNotEqual(2, alert.id)
+        self.assertNotEqual(old_alert.id, alert.id)
         self.assertFalse(alert.in_alarm)
         self.assertTrue(send_alert.called)
 

--- a/app/measurement/tests/test_monitor_api.py
+++ b/app/measurement/tests/test_monitor_api.py
@@ -22,7 +22,7 @@ from squac.test_mixins import sample_user
 to run only measurement tests:
     ./mg.sh "test measurement && flake8"
 to run only this file
-    "./mg.sh "test measurement.tests.test_monitor_api && flake8"
+    ./mg.sh "test measurement.tests.test_monitor_api && flake8"
 
 '''
 
@@ -211,8 +211,8 @@ class PrivateMonitorApiTests(TestCase):
 
         trigger = Trigger.objects.get(id=res.data['id'])
 
-        # should have no alert
-        self.assertIsNone(res.data['latest_alert'])
+        # should have an initial alert
+        self.assertIsNotNone(res.data['latest_alert'])
 
         # create alert with in_alarm True
         Alert.objects.create(


### PR DESCRIPTION
Default timestamps in alarming weren't being handled correctly, especially with Trigger.get_latest_alert()