### PR TITLE
Turn off LASTN monitor evaluation temporarily

### DIFF
--- a/app/measurement/management/commands/evaluate_alarms.py
+++ b/app/measurement/management/commands/evaluate_alarms.py
@@ -1,6 +1,10 @@
 from django.core.management.base import BaseCommand
 from measurement.models import Monitor
 
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+import pytz
+
 
 class Command(BaseCommand):
     """
@@ -20,6 +24,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         '''method called by manager'''
+        # Any monitors in this cycle should have the same endtime
+        endtime = datetime.now(tz=pytz.UTC) - relativedelta(
+            minute=0, second=0, microsecond=0)
 
         channel_groups = options['channel_group']
         metrics = options['metric']
@@ -35,4 +42,4 @@ class Command(BaseCommand):
 
         # Evaluate each alarm
         for monitor in monitors:
-            monitor.evaluate_alarm()
+            monitor.evaluate_alarm(endtime=endtime)

--- a/app/measurement/models.py
+++ b/app/measurement/models.py
@@ -167,9 +167,16 @@ class Monitor(MeasurementBase):
         metric = self.metric
         q_data = Measurement.objects.none()
 
+        # q_list is returned to the caller
+        q_list = []
+
         # Get a QuerySet containing only measurements for the correct time
         # period and metric for this alarm
         if self.interval_type == self.IntervalType.LASTN:
+            # 10/27/23 CWU: Temporarily disable LASTN evaluation since it was
+            # taking too many db resources
+            return q_list
+
             # Special case that isn't time-based
             # Restrict time window to reduce query time
             starttime = endtime - timedelta(weeks=1)
@@ -224,7 +231,6 @@ class Monitor(MeasurementBase):
         # Combine querysets in case of zero measurements. Kludgy but
         # shouldn't strain the db as much?
         q_dict = {obj['channel']: obj for obj in q_data}
-        q_list = []
         for chan_default in q_default:
             if chan_default['channel'] not in q_dict:
                 q_list.append(chan_default)


### PR DESCRIPTION
- When monitors take more than an hour to run, they aren't being evaluated for the original hour. Change logic so they reflect the original cronjob call time
- Turn off "last n" monitor evaluation. Queries were taking too long, hanging